### PR TITLE
Allow all aws-sdk credential providers to be used

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,13 +1,8 @@
 var aws = require('aws-sdk');
+var _ = require("lodash");
 
 module.exports = function(config) {
-	aws.config.update({
-		"accessKeyId" : config.credentials.accessKeyId,
-		"secretAccessKey" : config.credentials.secretAccessKey,
-		"region" : config.region
-	});
-
-	this.DynamoDB = new aws.DynamoDB({apiVersion: '2012-08-10'});
+	this.DynamoDB = new aws.DynamoDB(_.merge({apiVersion: '2012-08-10'}, config));
 	this.params = {};
 	return this;
 };


### PR DESCRIPTION
Fix for #2. Changes to initialization so that the default aws-sdk credentialProvider chain can be used, not just specifying the key/secret as hardcoded values.  Also allows other dynamodb options to be configured like httpAgent and maxRetries.
